### PR TITLE
chore: use MarkPad brand casing in user-facing text

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tagName: ${{ github.ref_name }}
-          releaseName: 'markpad ${{ github.ref_name }}'
+          releaseName: 'MarkPad ${{ github.ref_name }}'
           releaseBody: 'See the assets below to download and install this version.'
           releaseDraft: true
           prerelease: false

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,6 @@
 # Code of Conduct
 
-markpad should be a welcoming, respectful place to collaborate.
+MarkPad should be a welcoming, respectful place to collaborate.
 
 ## Expected Behavior
 
@@ -26,5 +26,5 @@ To report a conduct concern, contact the maintainer privately using the contact 
 
 ## Scope
 
-This code of conduct applies in project spaces, including GitHub issues, pull requests, discussions, releases, and any other community spaces connected to markpad.
+This code of conduct applies in project spaces, including GitHub issues, pull requests, discussions, releases, and any other community spaces connected to MarkPad.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
-# Contributing to markpad
+# Contributing to MarkPad
 
-Thanks for helping improve markpad, the Markdown editor with live preview.
+Thanks for helping improve MarkPad, the Markdown editor with live preview.
 
-markpad is early-stage and intentionally contributor-friendly: small issues, clear acceptance criteria, and reviewable pull requests are preferred over large surprise changes.
+MarkPad is early-stage and intentionally contributor-friendly: small issues, clear acceptance criteria, and reviewable pull requests are preferred over large surprise changes.
 
 ## Ways to Contribute
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
-  <img src="public/favicon.svg" alt="markpad logo" width="96">
+  <img src="public/favicon.svg" alt="MarkPad logo" width="96">
 </p>
 
-<h1 align="center">markpad</h1>
+<h1 align="center">MarkPad</h1>
 
 <p align="center">
   <strong>A lightweight, cross-platform Markdown editor with live preview.</strong>
@@ -31,15 +31,15 @@
 
 ---
 
-![markpad in the dark theme: a recent-files sidebar on the left, a flat single-surface layout, the Markdown formatting toolbar above the editor, sample Markdown in the editor pane, and its live rendering in the preview pane](docs/images/screenshot.png)
+![MarkPad in the dark theme: a recent-files sidebar on the left, a flat single-surface layout, the Markdown formatting toolbar above the editor, sample Markdown in the editor pane, and its live rendering in the preview pane](docs/images/screenshot.png)
 
-## Why markpad?
+## Why MarkPad?
 
 Most Markdown editors ask for a tradeoff: a heavyweight Electron app that ships a
 whole browser to render a text file, a web app that wants your documents in the
 cloud, or a bare editor with no live preview at all.
 
-markpad is the small, local-first alternative — a native desktop app that opens
+MarkPad is the small, local-first alternative — a native desktop app that opens
 quickly, keeps every file on your machine, and shows your Markdown rendered side
 by side as you type. A recent-files sidebar, a one-click formatting toolbar,
 light/dark theming, optional auto-save, and real OS file-association handling make
@@ -51,7 +51,7 @@ It is released under the [MIT License](LICENSE) and created by `lezli01` at
 
 ## Features
 
-Open a `.md` file and markpad treats editing and previewing as first-class,
+Open a `.md` file and MarkPad treats editing and previewing as first-class,
 side-by-side work:
 
 - **Live split-pane preview.** Edit Markdown on the left, see it rendered on the right, with each pane scrolling independently.
@@ -63,8 +63,8 @@ side-by-side work:
 - **New empty file.** Start a fresh Markdown document from the toolbar or `Ctrl+N` / `⌘N`; it appears in the recents list as an untitled draft, and the first Save prompts for a path.
 - **Light and dark theme.** Honors the operating system's appearance preference by default, with a manual toggle in the toolbar.
 - **Open files from disk.** Native file picker biased toward `.md` and `.markdown`, with a fallback to all files.
-- **Open files from your file manager.** Set markpad as the default for `.md` and a double-click opens markpad (or routes to the running instance).
-- **One window per user.** markpad runs as a single instance; new file requests bring the existing window to the foreground.
+- **Open files from your file manager.** Set MarkPad as the default for `.md` and a double-click opens MarkPad (or routes to the running instance).
+- **One window per user.** MarkPad runs as a single instance; new file requests bring the existing window to the foreground.
 - **Save back to disk.** Manual Save plus a visible modified indicator in the recents list so you always know whether your edits are on disk.
 - **Optional auto-save.** Tick the box once and edits land on disk shortly after you stop typing, while a file is open.
 - **Unsaved-change guard.** A file is never closed — only removed from the recents list. Removing an item that has unsaved edits prompts to Save, Discard, or Cancel so reflex clicks don't lose work.
@@ -136,7 +136,7 @@ docs/            Architecture notes and supporting docs
 
 ## Privacy
 
-markpad is local-first. Files stay on your machine and the application does not
+MarkPad is local-first. Files stay on your machine and the application does not
 send your content over the network. Preferences are stored in the local browser
 storage of the desktop runtime. Session state — your recent-files list, the active
 document, and any unsaved drafts — is stored locally in your platform's standard
@@ -154,7 +154,7 @@ restore are working today. Specs for shipped and in-progress features live under
 ## Contributing
 
 Contributions of every size are welcome — bug reports, docs, new features, and
-test cases. markpad is spec-driven and intentionally contributor-friendly: every
+test cases. MarkPad is spec-driven and intentionally contributor-friendly: every
 meaningful feature begins with a short spec under [`specs/`](specs) and clear
 acceptance criteria before implementation. Start here:
 
@@ -174,7 +174,7 @@ are in [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Security
 
-markpad is local-first and sanitizes all rendered HTML before display, so its
+MarkPad is local-first and sanitizes all rendered HTML before display, so its
 attack surface is small — but security reports are taken seriously. Please do not
 open a public issue for suspected vulnerabilities; report them privately via
 GitHub's private vulnerability reporting for this repository. See
@@ -182,4 +182,4 @@ GitHub's private vulnerability reporting for this repository. See
 
 ## License
 
-`markpad` is released under the [MIT License](LICENSE). © 2026 lezli01.
+MarkPad is released under the [MIT License](LICENSE). © 2026 lezli01.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-markpad is pre-1.0. Security fixes target the current `master` branch unless a release branch is explicitly documented later.
+MarkPad is pre-1.0. Security fixes target the current `master` branch unless a release branch is explicitly documented later.
 
 ## Reporting a Vulnerability
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,6 +1,6 @@
 # Support
 
-markpad is an early open-source project. The best support path depends on what you need.
+MarkPad is an early open-source project. The best support path depends on what you need.
 
 ## Bug Reports
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
-# markpad Architecture
+# MarkPad Architecture
 
-markpad is a cross-platform desktop Markdown editor/viewer.
+MarkPad is a cross-platform desktop Markdown editor/viewer.
 
 ## Frontend
 

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <title>markpad</title>
+    <title>MarkPad</title>
     <script>
       // Pre-React theme bootstrap — prevents a flash of the wrong theme on
       // first paint. Intentionally duplicates the first-launch resolution

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "productName": "markpad",
+  "productName": "MarkPad",
+  "mainBinaryName": "markpad",
   "version": "0.6.0",
   "identifier": "dev.is-a.lezli01.markpad",
   "build": {
@@ -12,7 +13,7 @@
   "app": {
     "windows": [
       {
-        "title": "markpad",
+        "title": "MarkPad",
         "width": 1200,
         "height": 800
       }

--- a/src/lib/fileOpen.ts
+++ b/src/lib/fileOpen.ts
@@ -179,7 +179,7 @@ export async function saveMarkdownFileAs(
 export async function setWindowTitle(fileName: string | null): Promise<void> {
   try {
     const win = getCurrentWebviewWindow();
-    await win.setTitle(fileName ? `${fileName} — markpad` : "markpad");
+    await win.setTitle(fileName ? `${fileName} — MarkPad` : "MarkPad");
   } catch (err) {
     console.warn("Failed to set window title:", err);
   }

--- a/src/lib/starterContent.ts
+++ b/src/lib/starterContent.ts
@@ -1,6 +1,6 @@
-export const starterContent = `# Welcome to markpad
+export const starterContent = `# Welcome to MarkPad
 
-**markpad** (Markdown editor with live preview) is a tiny desktop app that turns plain text into formatted reading on the fly.
+**MarkPad** (Markdown editor with live preview) is a tiny desktop app that turns plain text into formatted reading on the fly.
 
 ## What you're looking at
 


### PR DESCRIPTION
## What & why

The product name was written as fully-lowercase `markpad` **everywhere** — including every human-facing surface. This capitalizes it to **MarkPad** (capital M and P) wherever a human reads it, while leaving lowercase `markpad` intact for technical identifiers.

## Changed to `MarkPad` (human-facing)

- **App UI:** `tauri.conf.json` `productName` + window `title`, `index.html` `<title>`, the runtime window title in `src/lib/fileOpen.ts`, and the starter/welcome document in `src/lib/starterContent.ts`.
- **Docs:** README prose, headings, and image alt-text; `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, `SUPPORT.md`, `docs/architecture.md`.
- **Release:** the GitHub Release title in `.github/workflows/release.yml`.

## Kept lowercase (technical identifiers)

Added `mainBinaryName: "markpad"` to `tauri.conf.json` so the **display name is `MarkPad`** (Start menu, About, `.app`, installer) while the **on-disk executable stays `markpad`**.

Also left untouched: `package.json`/`Cargo.toml` `name`, the `dev.is-a.lezli01.markpad` bundle identifier, `localStorage` keys (`markpad.theme`, …), the `markpad://open-files` IPC event, the `markpad_lib` crate, the `.markpad-preview` CSS class, all `github.com`/`shields.io` URLs, and the README `#why-markpad` anchor (GitHub lowercases heading slugs, so it still resolves to `## Why MarkPad?`).

## Out of scope (intentionally not changed)

`specs/**`, `CHANGELOG.md` (release-please-generated), `AGENTS.md`, `CLAUDE.md`, `.claude/**`, `.agents/**`, `.specify/**`, `release-please-config.json`, and issue templates.

## Test plan

- `npm run lint` — clean
- `npm run test` — 71/71 pass
- `npm run build` — succeeds
- Verified `tauri.conf.json` still parses and the app-data directory is unaffected (it derives from the unchanged `identifier`, not `productName`), so stored preferences/session survive.
- Adversarially reviewed the diff from three independent lenses (completeness, breakage, casing consistency) — zero findings.

## Follow-up

`docs/images/screenshot.png` still shows the old lowercase `markpad` window title. It should be regenerated so the screenshot matches the new title bar (the README alt-text already says "MarkPad").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
