### PR TITLE
ci: build a single universal macOS artifact instead of per-arch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,7 @@ jobs:
       matrix:
         include:
           - platform: macos-latest
-            args: '--target aarch64-apple-darwin'
-          - platform: macos-latest
-            args: '--target x86_64-apple-darwin'
+            args: '--target universal-apple-darwin'
           - platform: ubuntu-22.04
             args: ''
           - platform: windows-latest


### PR DESCRIPTION
## What

Collapses the two macOS build-matrix entries in `release.yml` into one **universal** build:

```diff
         include:
-          - platform: macos-latest
-            args: '--target aarch64-apple-darwin'
-          - platform: macos-latest
-            args: '--target x86_64-apple-darwin'
+          - platform: macos-latest
+            args: '--target universal-apple-darwin'
           - platform: ubuntu-22.04
             args: ''
           - platform: windows-latest
             args: ''
```

## Why

The release currently produces **two** macOS downloads (Intel `x86_64` and Apple Silicon `aarch64`), forcing users to know their chip. A universal (fat Mach-O) binary packs both architecture slices into **one** `.dmg`/`.app` that runs natively on both — no Rosetta. macOS version is not a separate axis: a single build covers its minimum deployment target (Tauri default macOS 10.13) and all newer versions.

## Notes

- **No other change needed.** The Rust toolchain step already installs both required targets (`aarch64-apple-darwin,x86_64-apple-darwin`); `universal-apple-darwin` is a Tauri CLI virtual target that compiles both and merges them with `lipo`. The `matrix.platform == ''macos-latest''` condition still fires for the collapsed entry.
- No updater / `latest.json` is configured, so there is zero update-manifest impact.
- Windows and Linux have no fat-binary equivalent, so they are untouched.

## Trade-offs

- ✅ One macOS artifact instead of two; job count 4 → 3; slightly lower total mac-minutes (setup runs once).
- ⚠️ Longer Mac wall-clock: one runner compiles both arches sequentially + `lipo`, versus two parallel single-arch runners.
- ⚠️ Larger single download per user (both code slices; non-code resources are not duplicated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)