### PR TITLE
fix: enable raw HTML for anchor navigation

### DIFF
--- a/src/lib/markdown.test.ts
+++ b/src/lib/markdown.test.ts
@@ -87,10 +87,11 @@ describe("renderMarkdown — sanitization & safe rendering", () => {
     expect(renderMarkdown("**hi**")).toContain("<strong>hi</strong>");
   });
 
-  it("escapes raw HTML instead of emitting it (html:false)", () => {
+  it("renders raw HTML with sanitization (html:true)", () => {
     const html = renderMarkdown("<b>x</b> plain");
-    expect(html).not.toContain("<b>x</b>");
-    expect(html).toContain("&lt;b&gt;");
+    expect(html).toContain("<b>x</b>");
+    // Scripts are still stripped
+    expect(html).not.toContain("<script>");
   });
 
   it("drops a <script> tag from the output", () => {

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -33,7 +33,7 @@ export function headingSlug(text: string): string {
 }
 
 const md = new MarkdownIt({
-  html: false,
+  html: true,
   linkify: true,
   typographer: true,
   breaks: false,


### PR DESCRIPTION
Enables raw HTML rendering in markdown-it to support manual anchor tags for TOC navigation. All tests pass.