### PR TITLE
fix: theme the language toggle's drop-down list

### DIFF
--- a/src/components/Workspace.tsx
+++ b/src/components/Workspace.tsx
@@ -37,8 +37,16 @@ const paneHeader =
 const paneLabel =
   "shrink-0 text-xs font-medium uppercase tracking-wide text-[color:var(--muted)] select-none";
 
+// The drop-down list of a native <select> is painted by the browser, outside our
+// CSS tree, and it takes its surface from the control's own background. A
+// transparent control therefore leaves the open list on the platform's default
+// (light) palette even in the dark theme, so the background is set to the same
+// --bg the pane already shows through it — identical when closed, themed when
+// open — and the options carry the colors explicitly for the same reason.
 const languageSelect =
-  "shrink-0 rounded-md border border-[color:var(--border)] bg-transparent px-1.5 py-1 text-xs font-medium text-[color:var(--muted)] hover:text-[color:var(--text)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent)] transition-colors";
+  "shrink-0 rounded-md border border-[color:var(--border)] bg-[color:var(--bg)] px-1.5 py-1 text-xs font-medium text-[color:var(--muted)] hover:text-[color:var(--text)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent)] transition-colors";
+
+const languageOption = "bg-[color:var(--bg)] text-[color:var(--text)]";
 
 export default function Workspace({
   text,
@@ -119,8 +127,12 @@ export default function Workspace({
                 onLanguageChange(e.target.value as DocumentLanguage)
               }
             >
-              <option value="markdown">Markdown</option>
-              <option value="json">JSON</option>
+              <option className={languageOption} value="markdown">
+                Markdown
+              </option>
+              <option className={languageOption} value="json">
+                JSON
+              </option>
             </select>
           </div>
         </div>


### PR DESCRIPTION
Closes #74.

The pane-header Markdown / JSON toggle is a native `<select>`. Its closed
control was already themed; the list it opens was not.

## Why the open list ignored the theme

The drop-down list is painted by the browser, outside the page's CSS tree, and
Chromium takes its surface from the control's *own* computed `background-color`.
The control was `bg-transparent` — not an opaque colour — so the popup fell back
to the platform's light palette even with the app in the dark theme. The
`<option>` elements carried no colours of their own either.

`:root` already sets `color-scheme: light` / `dark` from `data-theme`, so
WebKit's native menu was fine; this was specific to the Chromium-painted popup
that Windows (WebView2) uses.

## The change

`src/components/Workspace.tsx`, two class strings:

- the control gets `bg-[color:var(--bg)]` instead of `bg-transparent`. The pane
  behind it *is* `--bg`, so the closed control is pixel-identical to before —
  but the popup now has an opaque, themed colour to derive its surface from.
- each `<option>` carries `bg-[color:var(--bg)] text-[color:var(--text)]`, so the
  rows are themed explicitly rather than relying on UA fallback behaviour.

`color-scheme` is untouched, and nothing about the toggle's value handling,
`aria-label` or behaviour changes.

## Verification

- Confirmed in the built stylesheet that both utilities compile to real
  declarations — `.bg-\[color\:var\(--bg\)\]{background-color:var(--bg)}` and
  `.text-\[color\:var\(--text\)\]{color:var(--text)}` — and that
  `:root{…color-scheme:light}` / `:root[data-theme=dark]{…color-scheme:dark}` are
  both emitted, so the values resolve per theme.
- `npx eslint src/components/Workspace.tsx` clean, `vite build` green, full test
  suite passes (88).
- **Not verified visually.** A native `<select>` popup is drawn by the browser
  and cannot be captured from a test, so the repaint itself wants one manual
  look: open a document, switch to the dark theme, and open the toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
