### PR TITLE
ci: bump every codeql-action step to v4.36.3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,3 +53,9 @@ updates:
     commit-message:
       prefix: ci
       include: scope
+    groups:
+      # The init and analyze steps must stay on the same version, so they have
+      # to be bumped by a single pull request.
+      codeql:
+        patterns:
+          - 'github/codeql-action*'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,12 +31,12 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           category: '/language:${{ matrix.language }}'


### PR DESCRIPTION
Replaces #45, which bumped `github/codeql-action/analyze` on its own and broke CodeQL.

## What was wrong

Dependabot tracks `github/codeql-action/init` and `github/codeql-action/analyze` as two
separate dependencies. `open-pull-requests-limit: 5` for the github-actions ecosystem was
already reached, so only the `analyze` bump got a PR. Both Analyze jobs on #45 failed with:

```
##[error]Loaded a configuration file for version '4.35.5', but running version '4.36.3'
##[error]analyze post-action step failed: Loaded a configuration file for version '4.35.5', but running version '4.36.3'
```

## What this changes

- `codeql.yml`: both steps move to `54f647b7e1bb85c95cddabcd46b0c578ec92bc1a` (v4.36.3),
  the same commit Dependabot pinned in #45.
- `dependabot.yml`: a `codeql` group for the github-actions ecosystem, so the next
  codeql-action release comes as one PR covering every step.

The version pin is the only change to the workflow; the matrix, languages, build mode and
`category` are untouched.
