### PR TITLE
ci: upload release bundles by release id on tauri-action v1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,14 +51,25 @@ jobs:
       - name: Install frontend dependencies
         run: npm ci
 
+      - name: Look up the release cut by release-please
+        id: release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          id=$(gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" \
+            --json databaseId --jq .databaseId 2>/dev/null || true)
+          if [ -z "$id" ]; then
+            echo "::error::no release exists for $GITHUB_REF_NAME - release-please cuts it when the release PR merges"
+            exit 1
+          fi
+          echo "id=$id" >> "$GITHUB_OUTPUT"
+
       - name: Build & publish Tauri bundles
-        uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # v0.6.2
+        uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # v1.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tagName: ${{ github.ref_name }}
-          releaseName: 'MarkPad ${{ github.ref_name }}'
-          releaseBody: 'See the assets below to download and install this version.'
-          releaseDraft: true
-          prerelease: false
+          releaseId: ${{ steps.release.outputs.id }}
+          uploadUpdaterJson: false
           args: ${{ matrix.args }}


### PR DESCRIPTION
Replaces #46, which bumps `tauri-apps/tauri-action` to v1.0.0 without touching the inputs.
Merging that PR on its own would break the next release.

## Why #46 alone breaks the release

Two v1.0.0 changes hit our setup, where release-please publishes the GitHub release the
moment the release PR merges and the tag push then starts this workflow ~12s later:

1. **"The action will now fail if `draft: true` is set but the relevant release is not a
   draft."** We pass `releaseDraft: true`. `create-release.ts` scans the release list, finds
   the tag, sees `draft: false`, warns `Found release with tag … but it's NOT a draft!`,
   throws `release not found`, and the fallback then tries to *create* a release for a tag
   that already has one — a 422 on all three platforms.
2. **"The action will now update the name and body of existing releases."** So keeping
   `releaseName`/`releaseBody` would overwrite release-please's changelog with
   `See the assets below to download and install this version.`. Dropping only those two
   inputs is worse: `releaseBody` reads as `''`, and `updateRelease` would blank the body.

## What this does instead

Resolve the release for the tag and pass `releaseId`. With an id set, tauri-action skips
`getOrCreateRelease` entirely (`if (tagName && !releaseId)`) and goes straight to
`uploadAssets(releaseId, …)`, so:

- release-please stays the only writer of the release name, body and draft state;
- tauri-action only attaches the bundles it just built;
- a tag with no release fails loudly in the lookup step instead of silently creating a
  second release. (`workflow_dispatch` on a branch now fails there — it previously produced
  a bogus `MarkPad master` release.)

`uploadUpdaterJson` is turned off explicitly: it defaults to `true` in v1 and the app has no
updater configured, so there is nothing to publish.

Other v1.0.0 breaking changes were checked against this workflow and do not apply: we set
none of `includeRelease`, `includeDebug`, `assetNamePattern`, `includeUpdaterJson`,
`updaterJsonKeepUniversal`, we do not rely on Tauri v1, Gitea, or `.app.tar.gz` names, and
the action never had to initialize the project.

`args: ${{ matrix.args }}` and the rest of the job are unchanged. This path can only be
exercised by an actual tag push, so it is worth watching the first release after this lands.
