### PR TITLE
ci: skip commitlint on dependabot's own commits

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,0 +1,12 @@
+/**
+ * Matches the config-conventional fallback the commit-lint workflow used before
+ * this file existed, with one exception: Dependabot's commits are skipped.
+ *
+ * Dependabot puts the full `.../compare/<sha>...<sha>` URL in the commit body,
+ * which is always longer than the 100 column body limit, so every one of its
+ * pull requests failed the required check on a line no human wrote.
+ */
+export default {
+  extends: ['@commitlint/config-conventional'],
+  ignores: [(message) => /^Signed-off-by: dependabot\[bot\]/m.test(message)],
+};


### PR DESCRIPTION
Every Dependabot PR fails the required `Commit messages are conventional` check on a line
Dependabot writes itself:

```
✖   body's lines must not be longer than 100 characters [body-max-line-length]
✖   found 1 problems, 0 warnings
```

The offending line is the `.../compare/<sha>...<sha>` URL in the generated body. The subject
is conventional, and the merge commit that lands on `master` is clean — so the red check has
never pointed at a real problem, but it is a required check, and it is the only reason the
weekly dependency merges need `--admin`.

## What this adds

The repo's first `commitlint.config.mjs`. `wagoid/commitlint-github-action` defaults to
`./commitlint.config.mjs` and falls back to `@commitlint/config-conventional` when the file
is missing, so the config keeps exactly the rule set that was already in force and adds one
thing: commits signed off by `dependabot[bot]` are ignored.

Human commits are unaffected — the 100 column body limit, the type/subject rules and
everything else in config-conventional still apply. `@commitlint/config-conventional` is
bundled in the action's image, so extending it needs no new dependency.
