### PR TITLE
ci: group routine npm dev-dependency bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,17 @@ updates:
       tauri:
         patterns:
           - '@tauri-apps/*'
+      # Routine dev-tooling churn lands in one pull request instead of one per
+      # package: master requires up-to-date branches, so every extra pull
+      # request costs its own rebase-and-recheck cycle. Majors stay ungrouped —
+      # a group is only as mergeable as its riskiest member. Each dependency
+      # goes to its most specific matching group, so @types/react* stays with
+      # react above and @tauri-apps/cli with tauri.
+      dev-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: cargo
     directory: /src-tauri


### PR DESCRIPTION
Closes #91.

Adds a `dev-dependencies` group to the npm ecosystem so routine dev-tooling
bumps arrive as one pull request instead of one per package:

```yaml
dev-dependencies:
  dependency-type: development
  update-types:
    - minor
    - patch
```

## Why minor and patch only

A grouped pull request is only as mergeable as its riskiest member. Majors stay
ungrouped so something like globals 15 to 17 or eslint 9 to 10 keeps arriving on
its own and can be verified in isolation.

## Why no exclude-patterns

Group assignment is by specificity, not by order in the file — Dependabot's
`assign_dependency_to_matching_groups` skips a group when
`should_skip_due_to_specificity?` finds a more specific match. The exact
patterns in the `react` group therefore keep `@types/react` and
`@types/react-dom`, and `@tauri-apps/*` keeps `@tauri-apps/cli`, even though all
three are dev dependencies that the new catch-all also matches.

Groups with non-overlapping `update-types` are treated as complementary rather
than competing, so restricting this group to minor and patch does not disturb
the existing pattern groups.

## Verification

- `.github/dependabot.yml` parses as YAML and the npm ecosystem resolves to four
  groups: `react`, `codemirror`, `tauri`, `dev-dependencies`.
- Production dependencies and the cargo and github-actions ecosystems are
  untouched — the diff is 11 added lines in one file.
- The grouping itself only takes effect on Dependabot's next weekly run, so the
  real confirmation is that next week's dev-tooling churn arrives as a single
  pull request with majors still separate.
