### PR TITLE
feat: notify when an open file changes on disk, with a reload option

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ side-by-side work:
 - **Save back to disk.** Manual Save plus a visible modified indicator in the recents list so you always know whether your edits are on disk.
 - **Optional auto-save.** Tick the box once and edits land on disk shortly after you stop typing, while a file is open.
 - **Unsaved-change guard.** Closing an item only drops it from the recents list; the file on disk is untouched. Closing one that has unsaved edits prompts to Save, Discard, or Cancel so reflex clicks don't lose work.
+- **Notices outside edits.** Change an open file in another program and MarkPad tells you when you come back to the window, offering **Reload from disk** or **Keep my version**; other open files that changed are marked in the recents list. A file merely touched, or saved with the same content, says nothing. Auto-save pauses until you answer, so it can never overwrite the other program's work behind your back, and a file deleted out from under you says so rather than offering a reload — your copy stays open, and saving writes the file again.
 - **Resumes where you left off.** Your recent-files list and the active document are restored on launch — including unsaved drafts and untitled documents, whose contents are saved locally so edits survive a restart. Files that have been moved or deleted are dropped when reopened.
 - **Persistent preferences.** Theme, view mode, auto-save, and the sidebar's width and collapsed state are remembered between launches, stored locally.
 - **Responsive layout.** Side-by-side on a normal window, stacks vertically at narrow widths.
@@ -177,7 +178,8 @@ application-data directory; nothing is sent over the network.
 Early development, but already usable day-to-day. The split-pane workspace, the
 recent-files sidebar with draft persistence, file open/save, view modes, theming,
 auto-save, JSON and YAML editing with formatting and folding, OS file-association
-handling, single-instance routing, and session restore are working today. Specs for shipped and in-progress features live under
+handling, single-instance routing, outside-edit detection, and session restore are
+working today. Specs for shipped and in-progress features live under
 [`specs/`](specs); open issues and follow-ups are in the
 [issue tracker](https://github.com/lezli01/markpad/issues).
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,6 +20,18 @@ application-data directory. User preferences (theme, view mode, auto-save,
 sidebar width/collapsed state) live in `localStorage` behind the single
 chokepoint `src/lib/preferences.ts`.
 
+## Outside Edits
+
+Buffers live in memory, so a file rewritten by another program has to be noticed
+before a save overwrites it. There is no filesystem watcher — that would mean a
+new dependency and a per-platform backend for a workflow that is entirely "the
+user comes back to MarkPad" — so the check is driven by window focus and by
+activating a recents entry. `src/lib/externalChange.ts` holds the policy: stat the
+path (`stat_text_file_by_path`), and only when the stamp moved, read it and
+compare the bytes with what the buffer believes is on disk. Comparing content is
+what keeps a touch, a same-bytes save, and MarkPad's own writes from raising a
+false notice.
+
 ## Editor
 
 CodeMirror 6 provides the editing surface for every language, with line numbers

--- a/src-tauri/src/launch_files.rs
+++ b/src-tauri/src/launch_files.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 
+use serde::Serialize;
 use serde_json::json;
 use tauri::{Emitter, Manager};
 
@@ -55,6 +56,42 @@ pub async fn read_text_file_by_path(path: String) -> Result<String, String> {
 #[tauri::command]
 pub async fn write_text_file_by_path(path: String, content: String) -> Result<(), String> {
     std::fs::write(&path, content).map_err(|err| err.to_string())
+}
+
+/// A cheap "was this file rewritten?" stamp: modification time in milliseconds
+/// since the Unix epoch, plus the byte length.
+///
+/// Coarse on purpose. A stamp match is only ever used to skip a read; anything
+/// that moved the stamp is confirmed against the file's actual bytes on the TS
+/// side (see lib/externalChange.ts), so a low-resolution mtime or a same-length
+/// rewrite costs one extra read rather than a wrong answer.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FileStamp {
+    pub mtime_ms: Option<i64>,
+    pub size: u64,
+}
+
+/// Stamp the file at `path`, or `None` when it no longer exists — a deletion is
+/// a normal outcome here (the file was renamed away or removed behind our back),
+/// not an error, so the frontend can report it as such. Every other io error is
+/// still an error.
+#[tauri::command]
+pub async fn stat_text_file_by_path(path: String) -> Result<Option<FileStamp>, String> {
+    let meta = match std::fs::metadata(&path) {
+        Ok(meta) => meta,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(err.to_string()),
+    };
+    let mtime_ms = meta
+        .modified()
+        .ok()
+        .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|since| since.as_millis() as i64);
+    Ok(Some(FileStamp {
+        mtime_ms,
+        size: meta.len(),
+    }))
 }
 
 pub fn bring_to_front(app: &tauri::AppHandle) {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,6 +27,7 @@ pub fn run() {
             launch_files::get_pending_files,
             launch_files::read_text_file_by_path,
             launch_files::write_text_file_by_path,
+            launch_files::stat_text_file_by_path,
             session::load_session,
             session::save_session
         ])

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import type { EditorState, StateEffect } from "@codemirror/state";
 import Workspace from "./components/Workspace";
 import Toolbar from "./components/Toolbar";
 import ErrorBanner from "./components/ErrorBanner";
+import ExternalChangeBanner from "./components/ExternalChangeBanner";
 import RecentsPanel, { type RecentEntry } from "./components/RecentsPanel";
 import ConfirmDialog from "./components/ConfirmDialog";
 import type { EditorHandle } from "./components/Editor";
@@ -16,10 +17,21 @@ import type { PreviewHandle } from "./components/Preview";
 import {
   openTextFile,
   openTextFileByPath,
+  openTextFileByPathWithStamp,
   saveTextFile,
   saveTextFileAs,
   setWindowTitle,
+  statTextFile,
+  subscribeToAppFocus,
 } from "./lib/fileOpen";
+import {
+  acknowledgedBaseline,
+  checkForExternalChange,
+  needsDiskCheck,
+  outcomeStillApplies,
+  type DiskBaseline,
+  type ExternalChange,
+} from "./lib/externalChange";
 import { getPendingFiles, subscribeToOpenFiles } from "./lib/launchFiles";
 import { loadSession, saveSession, type SessionItem } from "./lib/session";
 import {
@@ -67,6 +79,13 @@ export type RecentItem = {
       from the path" (see resolveLanguage). Cleared on Save-As, where the
       chosen extension becomes authoritative. */
   languageOverride: DocumentLanguage | null;
+  /** The disk revision this buffer has been reconciled against, for spotting
+      outside edits (see lib/externalChange.ts). Only meaningful while `loaded`. */
+  diskBaseline: DiskBaseline;
+  /** An outside edit to this file that the user has not answered yet; null when
+      there is none. Files whose buffer was released never carry one — they are
+      re-read from disk on activation. */
+  external: ExternalChange | null;
 };
 
 type ItemSnapshot = {
@@ -182,6 +201,9 @@ function App() {
   const sidebarWidthRef = useRef<number>(sidebarWidth);
   const activationSeqRef = useRef(0);
   const activeCounterRef = useRef(1);
+  // Guards the external-change sweep: focus events arrive in bursts (and from two
+  // sources), and one pass at a time is enough.
+  const sweepingRef = useRef(false);
 
   useEffect(() => {
     itemsRef.current = items;
@@ -210,6 +232,7 @@ function App() {
         path: t.path,
         modified: isModified(t),
         unsaved: hasUnsavedWork(t),
+        externallyChanged: t.external !== null,
       })),
     [items],
   );
@@ -253,7 +276,17 @@ function App() {
       setItems((list) =>
         list.map((t) =>
           t.id === prevId
-            ? { ...t, loaded: false, text: "", savedText: "" }
+            ? {
+                ...t,
+                loaded: false,
+                text: "",
+                savedText: "",
+                // No buffer left to compare against, so any disk bookkeeping is
+                // meaningless — and a leftover flag would show a marker for a
+                // file that will simply be re-read on its next activation.
+                diskBaseline: null,
+                external: null,
+              }
             : t,
         ),
       );
@@ -264,7 +297,7 @@ function App() {
     const item = itemsRef.current.find((t) => t.id === id);
     if (!item || item.kind !== "file" || !item.path) return;
     const seq = ++activationSeqRef.current;
-    const result = await openTextFileByPath(item.path);
+    const { result, stamp } = await openTextFileByPathWithStamp(item.path);
     if (seq !== activationSeqRef.current) return;
     if (result.kind === "ok") {
       setItems((list) =>
@@ -276,6 +309,8 @@ function App() {
                 text: result.content,
                 savedText: result.content,
                 name: result.name,
+                diskBaseline: stamp,
+                external: null,
               }
             : t,
         ),
@@ -287,6 +322,95 @@ function App() {
           : "This file could not be opened.",
       );
       removeItemImmediate(id);
+    }
+  }
+
+  /**
+   * Take the disk version of a file the user was told had changed underneath
+   * them. Replaces the buffer wholesale — the Editor rebuilds its state for a new
+   * document, so undo history starts fresh rather than being able to pull the
+   * pre-reload text back over content it never belonged to.
+   */
+  async function reloadItemFromDisk(id: ItemId): Promise<void> {
+    const item = itemsRef.current.find((t) => t.id === id);
+    if (!item || item.kind !== "file" || !item.path) return;
+    const seq = ++activationSeqRef.current;
+    const { result, stamp } = await openTextFileByPathWithStamp(item.path);
+    if (seq !== activationSeqRef.current) return;
+    if (result.kind !== "ok") {
+      // Unlike a lazy activation load, a failed reload must NOT drop the item:
+      // its buffer can hold the only copy of the user's work. Report it and leave
+      // the notice up so they can retry or keep their version.
+      setError(
+        result.kind === "error"
+          ? result.message
+          : "This file could not be reloaded.",
+      );
+      return;
+    }
+    setItems((list) =>
+      list.map((t) =>
+        t.id === id
+          ? {
+              ...t,
+              loaded: true,
+              text: result.content,
+              savedText: result.content,
+              name: result.name,
+              diskBaseline: stamp,
+              external: null,
+            }
+          : t,
+      ),
+    );
+    setError(null);
+  }
+
+  /** Stop showing a notice without taking the disk version: remember the revision
+      the user was shown, so the same one never interrupts them twice. */
+  function acknowledgeExternalChange(id: ItemId) {
+    const item = itemsRef.current.find((t) => t.id === id);
+    if (!item || item.external === null) return;
+    const baseline = acknowledgedBaseline(item.external);
+    setItems((list) =>
+      list.map((t) =>
+        t.id === id ? { ...t, external: null, diskBaseline: baseline } : t,
+      ),
+    );
+  }
+
+  /**
+   * Compare every buffer we hold against its file on disk. Runs when the window
+   * regains focus and when an item is activated — see lib/externalChange.ts for
+   * why those two moments, and for the stat-then-read protocol.
+   */
+  async function checkOpenFilesAgainstDisk(): Promise<void> {
+    if (sweepingRef.current) return;
+    sweepingRef.current = true;
+    try {
+      const targets = itemsRef.current.filter(needsDiskCheck);
+      for (const item of targets) {
+        const outcome = await checkForExternalChange(
+          { stat: statTextFile, read: openTextFileByPath },
+          {
+            // needsDiskCheck already established the path.
+            path: item.path!,
+            savedText: item.savedText,
+            diskBaseline: item.diskBaseline,
+          },
+        );
+        setItems((list) =>
+          list.map((t) => {
+            if (t.id !== item.id) return t;
+            if (!outcomeStillApplies(item, t)) return t;
+            return outcome.kind === "unchanged"
+              ? { ...t, diskBaseline: outcome.baseline }
+              : { ...t, external: outcome.change };
+          }),
+        );
+      }
+    } finally {
+      sweepingRef.current = false;
     }
   }
 
@@ -302,6 +426,10 @@ function App() {
     // updateActiveItemText, only on the first (clean → dirty) edit.
     if (target.kind === "file" && !target.loaded) {
       await loadItemFromDisk(id);
+    } else if (target.kind === "file") {
+      // A buffer we kept (a modified file) can have gone stale since it was last
+      // looked at; say so now rather than waiting for the next focus.
+      await checkOpenFilesAgainstDisk();
     }
   }
 
@@ -364,6 +492,8 @@ function App() {
               savedText,
               lastActive: stamp,
               languageOverride: asDocumentLanguage(s.language),
+              diskBaseline: null,
+              external: null,
             };
           }
           const path = s.path ?? "";
@@ -379,6 +509,12 @@ function App() {
               savedText: s.saved_text ?? "",
               lastActive: stamp,
               languageOverride: asDocumentLanguage(s.language),
+              // Stamps are not persisted, so a restored draft starts with an
+              // unknown baseline. That is what makes the first check read and
+              // compare bytes — which is exactly how a file edited while markpad
+              // was closed gets reported.
+              diskBaseline: null,
+              external: null,
             };
           }
           return {
@@ -391,6 +527,8 @@ function App() {
             savedText: "",
             lastActive: stamp,
             languageOverride: asDocumentLanguage(s.language),
+            diskBaseline: null,
+            external: null,
           };
         })
         .filter((t) => t.kind === "untitled" || (t.path?.length ?? 0) > 0);
@@ -502,6 +640,10 @@ function App() {
     if (activeItem.kind !== "file" || !activeItem.path) return;
     if (activeItem.text === activeItem.savedText) return;
     if (savingById[activeItem.id]) return;
+    // Hold off while an outside edit is waiting on the user: auto-saving here
+    // would overwrite it before they had a chance to look. Answering the notice
+    // either way — reload, or keep my version — releases the hold.
+    if (activeItem.external !== null) return;
     const id = activeItem.id;
     const handle = setTimeout(() => {
       void performSave(id);
@@ -544,6 +686,8 @@ function App() {
       savedText: "",
       lastActive: stamp,
       languageOverride: null,
+      diskBaseline: null,
+      external: null,
     };
     const prevActive = activeIdRef.current;
     setItems((prev) => capList([...prev, newItem], id, prevActive));
@@ -574,6 +718,8 @@ function App() {
         savedText: result.content,
         lastActive: stamp,
         languageOverride: null,
+        diskBaseline: null,
+        external: null,
       };
       const prevActive = activeIdRef.current;
       setItems((prev) => capList([...prev, newItem], id, prevActive));
@@ -609,6 +755,8 @@ function App() {
         savedText: "",
         lastActive: stamp,
         languageOverride: null,
+        diskBaseline: null,
+        external: null,
       };
       const prevActive = activeIdRef.current;
       const next = capList([...itemsRef.current, newItem], id, prevActive);
@@ -675,6 +823,8 @@ function App() {
                   languageOverride: hasLanguageExtension(result.path)
                     ? null
                     : t.languageOverride,
+                  diskBaseline: null,
+                  external: null,
                 }
               : t,
           ),
@@ -689,7 +839,21 @@ function App() {
       const result = await saveTextFile(item.path, outbound);
       if (result.kind === "ok") {
         setItems((list) =>
-          list.map((t) => (t.id === id ? { ...t, savedText: outbound } : t)),
+          list.map((t) =>
+            t.id === id
+              ? {
+                  ...t,
+                  savedText: outbound,
+                  // Our own write moves the stamp, so the old baseline is stale.
+                  // Clearing it makes the next check read once and find the bytes
+                  // it already expects — no notice, and no bookkeeping to get
+                  // wrong. Clearing `external` records the user's intent when
+                  // they saved over a reported change: their version wins.
+                  diskBaseline: null,
+                  external: null,
+                }
+              : t,
+          ),
         );
         setError(null);
         success = true;
@@ -853,13 +1017,34 @@ function App() {
   const handleNewFileRef = useRef(handleNewFile);
   const handleOpenFileRef = useRef(handleOpenFile);
   const handleToggleSidebarRef = useRef(handleToggleSidebar);
+  const checkAgainstDiskRef = useRef(checkOpenFilesAgainstDisk);
 
   useEffect(() => {
     handleSaveRef.current = handleSave;
     handleNewFileRef.current = handleNewFile;
     handleOpenFileRef.current = handleOpenFile;
     handleToggleSidebarRef.current = handleToggleSidebar;
+    checkAgainstDiskRef.current = checkOpenFilesAgainstDisk;
   });
+
+  // --- Coming back to the window: compare the open buffers with disk. ---
+  useEffect(() => {
+    let cancelled = false;
+    let unsubscribe: (() => void) | null = null;
+
+    void (async () => {
+      const off = await subscribeToAppFocus(() => {
+        void checkAgainstDiskRef.current();
+      });
+      if (cancelled) off();
+      else unsubscribe = off;
+    })();
+
+    return () => {
+      cancelled = true;
+      unsubscribe?.();
+    };
+  }, []);
 
   useEffect(() => {
     function onKeyDown(e: KeyboardEvent) {
@@ -938,6 +1123,15 @@ function App() {
         />
         {error !== null && (
           <ErrorBanner message={error} onDismiss={() => setError(null)} />
+        )}
+        {activeItem !== null && activeItem.external !== null && (
+          <ExternalChangeBanner
+            name={activeItem.name}
+            kind={activeItem.external.kind}
+            unsaved={hasUnsavedWork(activeItem)}
+            onReload={() => void reloadItemFromDisk(activeItem.id)}
+            onDismiss={() => acknowledgeExternalChange(activeItem.id)}
+          />
         )}
         <div className="flex-1 min-h-0">
           {activeItem === null ? (

--- a/src/components/ExternalChangeBanner.tsx
+++ b/src/components/ExternalChangeBanner.tsx
@@ -1,0 +1,113 @@
+// Shown when the file in the active pane was rewritten (or removed) on disk
+// behind markpad's back — see lib/externalChange.ts for how that is detected.
+//
+// Deliberately a banner and not a modal: the user has just come back to the
+// window and may well want to look at their buffer before deciding. Nothing is
+// reloaded without them asking, so leaving the banner up is always safe.
+
+type ExternalChangeBannerProps = {
+  name: string;
+  kind: "changed" | "deleted";
+  /** True when reloading would throw away edits the user has not saved. */
+  unsaved: boolean;
+  onReload(): void;
+  onDismiss(): void;
+};
+
+// Indigo rather than <ErrorBanner />'s amber: nothing has gone wrong, there is
+// just a decision to make.
+const bannerShell =
+  "flex flex-wrap items-center gap-x-3 gap-y-2 border-b border-[color:var(--border)] border-l-2 border-l-[color:var(--accent)] bg-[color:var(--accent-soft)] px-4 py-2 text-[color:var(--text)]";
+
+const actionButton =
+  "shrink-0 inline-flex items-center rounded-md border border-[color:var(--border)] bg-[color:var(--panel)] px-2.5 py-1 text-xs font-medium hover:bg-[color:var(--hover)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent)] transition-colors";
+
+const primaryButton =
+  "shrink-0 inline-flex items-center rounded-md border border-transparent bg-[color:var(--accent)] px-2.5 py-1 text-xs font-medium text-[color:var(--accent-fg)] hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent)] transition-opacity";
+
+function ChangedIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      width="15"
+      height="15"
+      className="shrink-0 text-[color:var(--accent)]"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M21 12a9 9 0 1 1-2.64-6.36" />
+      <path d="M21 3v5h-5" />
+    </svg>
+  );
+}
+
+function DeletedIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      width="15"
+      height="15"
+      className="shrink-0 text-[color:var(--accent)]"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <circle cx="12" cy="12" r="9" />
+      <path d="M12 8v4M12 16h.01" />
+    </svg>
+  );
+}
+
+export default function ExternalChangeBanner({
+  name,
+  kind,
+  unsaved,
+  onReload,
+  onDismiss,
+}: ExternalChangeBannerProps) {
+  if (kind === "deleted") {
+    return (
+      <div className={bannerShell} role="status">
+        <DeletedIcon />
+        <span className="text-sm">
+          <span className="font-medium">{name}</span> no longer exists on disk.
+          Your copy is still open here — save it to write the file again.
+        </span>
+        <button
+          type="button"
+          className={`${actionButton} ml-auto`}
+          onClick={onDismiss}
+        >
+          Keep in editor
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className={bannerShell} role="status">
+      <ChangedIcon />
+      <span className="text-sm">
+        <span className="font-medium">{name}</span> has changed on disk.
+        {unsaved
+          ? " Reloading discards the unsaved changes in this buffer."
+          : " Reload to pick up the new content."}
+      </span>
+      <div className="ml-auto flex items-center gap-2">
+        <button type="button" className={primaryButton} onClick={onReload}>
+          Reload from disk
+        </button>
+        <button type="button" className={actionButton} onClick={onDismiss}>
+          Keep my version
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/RecentsPanel.tsx
+++ b/src/components/RecentsPanel.tsx
@@ -14,6 +14,10 @@ export type RecentEntry = {
   /** True when the buffer differs from its saved baseline. Unlike `modified`,
       an untouched untitled draft counts as saved, so bulk closes may take it. */
   unsaved: boolean;
+  /** True when the file was changed or removed on disk by something else and the
+      user has not dealt with it yet — shows a marker on the row. The banner with
+      the actual choice appears once the item is active. */
+  externallyChanged: boolean;
 };
 
 type RecentsPanelProps = {
@@ -84,6 +88,28 @@ function CloseIcon() {
       strokeLinejoin="round"
     >
       <path d="M6 6l12 12M18 6L6 18" />
+    </svg>
+  );
+}
+
+// Marks a row whose file changed on disk. Kept visually distinct from the
+// modified dot on the left — that one is about the buffer, this one is about the
+// file — and never hidden on hover, unlike the close button it sits beside.
+function DiskChangeIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      width="13"
+      height="13"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M21 12a9 9 0 1 1-2.64-6.36" />
+      <path d="M21 3v5h-5" />
     </svg>
   );
 }
@@ -203,6 +229,9 @@ export default function RecentsPanel({
                         {item.modified && (
                           <span className="sr-only">Modified. </span>
                         )}
+                        {item.externallyChanged && (
+                          <span className="sr-only">Changed on disk. </span>
+                        )}
                         {item.name}
                       </span>
                       {item.path && (
@@ -222,6 +251,17 @@ export default function RecentsPanel({
                       )}
                     </span>
                   </button>
+                  {item.externallyChanged && (
+                    <span
+                      // The row's own accessible name already carries this (see
+                      // the sr-only text above), so the glyph is decorative;
+                      // the tooltip is for sighted users.
+                      title="Changed on disk"
+                      className="shrink-0 inline-flex items-center justify-center p-0.5 text-[color:var(--accent)]"
+                    >
+                      <DiskChangeIcon />
+                    </span>
+                  )}
                   <button
                     type="button"
                     aria-label={`Close ${item.name}`}

--- a/src/lib/externalChange.test.ts
+++ b/src/lib/externalChange.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  acknowledgedBaseline,
+  checkForExternalChange,
+  needsDiskCheck,
+  outcomeStillApplies,
+  sameStamp,
+  type CheckDeps,
+  type DiskBaseline,
+  type WatchTarget,
+} from "./externalChange";
+import type { DiskStamp, OpenResult, StatResult } from "./fileOpen";
+
+const PATH = "/tmp/notes.md";
+const SAVED = "# Notes\n";
+
+function stamp(mtimeMs: number | null, size: number): DiskStamp {
+  return { mtimeMs, size };
+}
+
+// Deps whose two halves are independently scripted, so a test can assert that
+// the read never happened on the stat-only fast path.
+function deps(stat: StatResult, read: OpenResult = { kind: "cancelled" }) {
+  const fns: CheckDeps = {
+    stat: vi.fn(async () => stat),
+    read: vi.fn(async () => read),
+  };
+  return fns as CheckDeps & {
+    stat: ReturnType<typeof vi.fn>;
+    read: ReturnType<typeof vi.fn>;
+  };
+}
+
+function onDisk(content: string): OpenResult {
+  return { kind: "ok", name: "notes.md", path: PATH, content };
+}
+
+function target(diskBaseline: DiskBaseline) {
+  return { path: PATH, savedText: SAVED, diskBaseline };
+}
+
+function watched(over: Partial<WatchTarget> = {}): WatchTarget {
+  return {
+    kind: "file",
+    path: PATH,
+    loaded: true,
+    savedText: SAVED,
+    diskBaseline: null,
+    external: null,
+    ...over,
+  };
+}
+
+describe("sameStamp", () => {
+  it("compares both mtime and size", () => {
+    expect(sameStamp(stamp(1000, 8), stamp(1000, 8))).toBe(true);
+    expect(sameStamp(stamp(1000, 8), stamp(2000, 8))).toBe(false);
+    expect(sameStamp(stamp(1000, 8), stamp(1000, 9))).toBe(false);
+  });
+
+  it("treats an unavailable mtime as a value, not a wildcard", () => {
+    expect(sameStamp(stamp(null, 8), stamp(null, 8))).toBe(true);
+    expect(sameStamp(stamp(null, 8), stamp(1000, 8))).toBe(false);
+  });
+});
+
+describe("checkForExternalChange", () => {
+  it("stops at the stat when the stamp still matches", async () => {
+    const d = deps({ kind: "ok", stamp: stamp(1000, 8) });
+    const outcome = await checkForExternalChange(d, target(stamp(1000, 8)));
+
+    expect(outcome).toEqual({ kind: "unchanged", baseline: stamp(1000, 8) });
+    expect(d.read).not.toHaveBeenCalled();
+  });
+
+  it("reports a change when the stamp moved and the bytes differ", async () => {
+    const d = deps(
+      { kind: "ok", stamp: stamp(2000, 20) },
+      onDisk("# Notes\n\nedited elsewhere\n"),
+    );
+    const outcome = await checkForExternalChange(d, target(stamp(1000, 8)));
+
+    expect(outcome).toEqual({
+      kind: "changed",
+      change: { kind: "changed", stamp: stamp(2000, 20) },
+    });
+  });
+
+  it("stays quiet when the stamp moved but the bytes did not", async () => {
+    const d = deps({ kind: "ok", stamp: stamp(2000, 8) }, onDisk(SAVED));
+    const outcome = await checkForExternalChange(d, target(stamp(1000, 8)));
+
+    // A touch, or markpad's own save. Recording the stamp is what keeps the next
+    // check on the fast path instead of re-reading forever.
+    expect(outcome).toEqual({ kind: "unchanged", baseline: stamp(2000, 8) });
+    expect(d.read).toHaveBeenCalledTimes(1);
+  });
+
+  it("reads once to settle an unknown baseline", async () => {
+    const d = deps({ kind: "ok", stamp: stamp(1000, 8) }, onDisk(SAVED));
+    const outcome = await checkForExternalChange(d, target(null));
+
+    expect(outcome).toEqual({ kind: "unchanged", baseline: stamp(1000, 8) });
+    expect(d.read).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports a change an unknown baseline turns out to be hiding", async () => {
+    // Session restore: the file was edited while markpad was closed, so there is
+    // no stamp to compare and only the bytes can tell.
+    const d = deps({ kind: "ok", stamp: stamp(9000, 40) }, onDisk("elsewhere"));
+    const outcome = await checkForExternalChange(d, target(null));
+
+    expect(outcome).toEqual({
+      kind: "changed",
+      change: { kind: "changed", stamp: stamp(9000, 40) },
+    });
+  });
+
+  it("reports a file that is gone", async () => {
+    const d = deps({ kind: "missing" });
+    const outcome = await checkForExternalChange(d, target(stamp(1000, 8)));
+
+    expect(outcome).toEqual({
+      kind: "changed",
+      change: { kind: "deleted" },
+    });
+    expect(d.read).not.toHaveBeenCalled();
+  });
+
+  it("does not re-report a deletion the user already acknowledged", async () => {
+    const d = deps({ kind: "missing" });
+    const outcome = await checkForExternalChange(d, target("missing"));
+
+    expect(outcome).toEqual({ kind: "unchanged", baseline: "missing" });
+  });
+
+  it("compares bytes when an acknowledged-missing file reappears", async () => {
+    const d = deps({ kind: "ok", stamp: stamp(3000, 8) }, onDisk(SAVED));
+    const outcome = await checkForExternalChange(d, target("missing"));
+
+    expect(outcome).toEqual({ kind: "unchanged", baseline: stamp(3000, 8) });
+  });
+
+  it("keeps quiet and keeps the baseline when the stat fails", async () => {
+    const d = deps({ kind: "error", message: "locked" });
+    const outcome = await checkForExternalChange(d, target(stamp(1000, 8)));
+
+    expect(outcome).toEqual({ kind: "unchanged", baseline: stamp(1000, 8) });
+    expect(d.read).not.toHaveBeenCalled();
+  });
+
+  it("keeps quiet and keeps the baseline when the read fails", async () => {
+    // Half-written file mid-save by the other program: retry on the next check
+    // rather than interrupt with a change we cannot describe.
+    const d = deps(
+      { kind: "ok", stamp: stamp(2000, 20) },
+      { kind: "error", message: "locked" },
+    );
+    const outcome = await checkForExternalChange(d, target(stamp(1000, 8)));
+
+    expect(outcome).toEqual({ kind: "unchanged", baseline: stamp(1000, 8) });
+  });
+});
+
+describe("needsDiskCheck", () => {
+  it("checks a loaded file with nothing pending", () => {
+    expect(needsDiskCheck(watched())).toBe(true);
+  });
+
+  it("skips untitled drafts, which have no file", () => {
+    const draft = watched({ kind: "untitled", path: null });
+    expect(needsDiskCheck(draft)).toBe(false);
+  });
+
+  it("skips a released buffer, which is re-read on activation anyway", () => {
+    const released = watched({ loaded: false, savedText: "" });
+    expect(needsDiskCheck(released)).toBe(false);
+  });
+
+  it("skips an item whose change the user has not answered yet", () => {
+    const flagged = watched({ external: { kind: "deleted" } });
+    expect(needsDiskCheck(flagged)).toBe(false);
+  });
+});
+
+describe("outcomeStillApplies", () => {
+  const checked = watched({ diskBaseline: stamp(1000, 8) });
+
+  it("applies when nothing moved underneath the check", () => {
+    const current = watched({ diskBaseline: stamp(1000, 8) });
+    expect(outcomeStillApplies(checked, current)).toBe(true);
+  });
+
+  it("drops an answer invalidated by a save landing mid-sweep", () => {
+    const saved = watched({ savedText: "saved since" });
+    expect(outcomeStillApplies(checked, saved)).toBe(false);
+  });
+
+  it("drops an answer for a buffer released mid-sweep", () => {
+    const released = watched({ loaded: false, savedText: "" });
+    expect(outcomeStillApplies(checked, released)).toBe(false);
+  });
+
+  it("drops an answer for a file saved under a new path", () => {
+    const moved = watched({ path: "/tmp/other.md" });
+    expect(outcomeStillApplies(checked, moved)).toBe(false);
+  });
+});
+
+describe("acknowledgedBaseline", () => {
+  it("remembers the revision the user was shown", () => {
+    const change = { kind: "changed", stamp: stamp(2000, 20) } as const;
+    expect(acknowledgedBaseline(change)).toEqual(stamp(2000, 20));
+  });
+
+  it("remembers that a deletion was reported", () => {
+    expect(acknowledgedBaseline({ kind: "deleted" })).toBe("missing");
+  });
+});

--- a/src/lib/externalChange.ts
+++ b/src/lib/externalChange.ts
@@ -1,0 +1,167 @@
+// Noticing that a file open in markpad was rewritten behind its back — by
+// another editor, a formatter, a `git checkout`, a script. markpad keeps buffers
+// in memory, so without this the screen quietly diverges from disk and the next
+// save overwrites the other program's work.
+//
+// There is no filesystem watcher (that would mean a new dependency and a
+// per-platform backend for a workflow that is entirely "the user comes back to
+// markpad"). Instead the check runs at the moments the user could have returned
+// from another program: the window regaining focus, and activating an item in
+// the recents list.
+//
+// Each check is two steps:
+//
+//   1. stat the path. Nothing else happens if the stamp still matches the
+//      revision we last reconciled with — the common case, and it never reads.
+//   2. only when the stamp moved, read the file and compare its bytes with the
+//      buffer's saved baseline.
+//
+// Step 2 is what keeps the notice honest. `touch`, a save that wrote identical
+// bytes, and markpad's own writes all move the stamp without changing content,
+// and none of them should interrupt the user. Comparing content also means a
+// stamp we never recorded (a fresh load, a restored session, the moment after a
+// save) is safe to leave unknown: the first check just reads once and settles.
+
+import type { DiskStamp, OpenResult, StatResult } from "./fileOpen";
+
+/**
+ * The disk revision markpad has already reconciled with the user:
+ *   - a stamp — disk was confirmed to match the buffer's saved baseline, or the
+ *     user acknowledged the difference and chose to keep their version;
+ *   - `"missing"` — the user has been told the file is gone;
+ *   - `null` — unknown, so the next check reads to find out.
+ *
+ * Deliberately not the same thing as "the stamp of savedText": once the user
+ * dismisses a notice we must not raise it again for the same revision.
+ */
+export type DiskBaseline = DiskStamp | "missing" | null;
+
+/** An outside edit that has not been shown to the user and acted on yet. */
+export type ExternalChange =
+  | { kind: "changed"; stamp: DiskStamp }
+  | { kind: "deleted" };
+
+export type CheckTarget = {
+  path: string;
+  /** The bytes markpad believes are on disk for this buffer. */
+  savedText: string;
+  diskBaseline: DiskBaseline;
+};
+
+/** The part of a recents item this module reasons about; RecentItem satisfies it
+    structurally, so App passes its items straight in. */
+export type WatchTarget = {
+  kind: "file" | "untitled";
+  path: string | null;
+  loaded: boolean;
+  savedText: string;
+  diskBaseline: DiskBaseline;
+  external: ExternalChange | null;
+};
+
+export type CheckOutcome =
+  /** Nothing to tell the user. `baseline` is what to remember: the freshly
+      confirmed stamp when we read, or the previous value when we could not. */
+  | { kind: "unchanged"; baseline: DiskBaseline }
+  | { kind: "changed"; change: ExternalChange };
+
+export type CheckDeps = {
+  stat(path: string): Promise<StatResult>;
+  read(path: string): Promise<OpenResult>;
+};
+
+function isStamp(baseline: DiskBaseline): baseline is DiskStamp {
+  return baseline !== null && baseline !== "missing";
+}
+
+export function sameStamp(a: DiskStamp, b: DiskStamp): boolean {
+  return a.size === b.size && a.mtimeMs === b.mtimeMs;
+}
+
+/** The baseline to record once the user has been shown `change` and dealt with
+    it, either by reloading or by keeping their version. */
+export function acknowledgedBaseline(change: ExternalChange): DiskBaseline {
+  return change.kind === "deleted" ? "missing" : change.stamp;
+}
+
+/**
+ * Whether a sweep should look at this item at all.
+ *
+ * Untitled drafts have no file behind them. A released clean file has no buffer
+ * that could be stale — activating it re-reads from disk regardless. And an item
+ * already carrying a change has nothing further to learn: the user has been told,
+ * and re-reading it on every focus would buy nothing. (If disk moves on again,
+ * the stamp recorded when they answer the notice is older than the file's, so the
+ * next sweep picks the newer revision up.)
+ */
+export function needsDiskCheck(item: WatchTarget): boolean {
+  return (
+    item.kind === "file" &&
+    item.path !== null &&
+    item.loaded &&
+    item.external === null
+  );
+}
+
+/**
+ * Whether an outcome computed for `checked` may still be written onto `current`.
+ *
+ * The sweep awaits disk between reading an item and updating it, so a save, a
+ * reload, or a buffer release can land in between. Each of those resets what the
+ * buffer believes is on disk, which makes the in-flight answer meaningless rather
+ * than merely late — dropping it lets the next sweep start from the new state.
+ */
+export function outcomeStillApplies(
+  checked: WatchTarget,
+  current: WatchTarget,
+): boolean {
+  return (
+    current.loaded &&
+    current.path === checked.path &&
+    current.savedText === checked.savedText
+  );
+}
+
+/**
+ * Compare one open file against disk. Reads only when the stamp says it must.
+ *
+ * A stat or read that fails for any reason other than "the file is gone" is
+ * treated as "nothing to report": the file may be momentarily locked by the very
+ * program that is writing it, and a transient error is not something to
+ * interrupt the user with. The baseline is left untouched so the next check
+ * tries again.
+ */
+export async function checkForExternalChange(
+  deps: CheckDeps,
+  target: CheckTarget,
+): Promise<CheckOutcome> {
+  const stat = await deps.stat(target.path);
+  if (stat.kind === "missing") {
+    return target.diskBaseline === "missing"
+      ? { kind: "unchanged", baseline: target.diskBaseline }
+      : { kind: "changed", change: { kind: "deleted" } };
+  }
+  if (stat.kind === "error") {
+    return { kind: "unchanged", baseline: target.diskBaseline };
+  }
+  if (
+    isStamp(target.diskBaseline) &&
+    sameStamp(stat.stamp, target.diskBaseline)
+  ) {
+    return { kind: "unchanged", baseline: target.diskBaseline };
+  }
+
+  const read = await deps.read(target.path);
+  if (read.kind !== "ok") {
+    return { kind: "unchanged", baseline: target.diskBaseline };
+  }
+  if (read.content === target.savedText) {
+    // The stamp moved but the bytes did not: a touch, or our own save. Record
+    // the new stamp so the next check stops at the stat.
+    return { kind: "unchanged", baseline: stat.stamp };
+  }
+  return {
+    kind: "changed",
+    change: { kind: "changed", stamp: stat.stamp },
+  };
+}

--- a/src/lib/fileOpen.ts
+++ b/src/lib/fileOpen.ts
@@ -7,6 +7,9 @@
 //   - src/lib/session.ts        owns load_session / save_session
 //   - src/lib/launchFiles.ts    owns get_pending_files + markpad://open-files event
 //
+// statTextFile and subscribeToAppFocus are the two primitives external-change
+// detection needs; the policy that uses them lives in src/lib/externalChange.ts.
+//
 // Note: openTextFileByPath reads via the Rust `read_text_file_by_path`
 // command rather than the fs plugin's readTextFile because programmatic paths
 // (CLI args, OS file activations, session restore) don't get the fs plugin's
@@ -38,6 +41,14 @@ const SAVE_FILTERS: Record<
 export type OpenResult =
   | { kind: "ok"; name: string; path: string; content: string }
   | { kind: "cancelled" }
+  | { kind: "error"; message: string };
+
+/** Cheap change stamp for a file on disk; see FileStamp in launch_files.rs. */
+export type DiskStamp = { mtimeMs: number | null; size: number };
+
+export type StatResult =
+  | { kind: "ok"; stamp: DiskStamp }
+  | { kind: "missing" }
   | { kind: "error"; message: string };
 
 export type SaveResult = { kind: "ok" } | { kind: "error"; message: string };
@@ -106,6 +117,43 @@ export async function openTextFileByPath(path: string): Promise<OpenResult> {
     };
   } catch (err) {
     console.warn("Failed to read file by path:", err);
+    return { kind: "error", message: friendlyMessage(err) };
+  }
+}
+
+/**
+ * Read a file and stamp it in one go, for the callers that want a baseline to
+ * compare against later (see lib/externalChange.ts).
+ *
+ * The stamp is taken FIRST, on purpose: a write landing between the two calls
+ * then leaves a stamp that looks older than the content it labels, which costs
+ * one redundant read on the next check. Stamping afterwards would leave one that
+ * looks current for content we never saw, hiding that change for good.
+ *
+ * `stamp` is null when only the stat failed — an unknown baseline is safe, it
+ * just means the next check reads instead of trusting the stamp.
+ */
+export async function openTextFileByPathWithStamp(
+  path: string,
+): Promise<{ result: OpenResult; stamp: DiskStamp | null }> {
+  const stat = await statTextFile(path);
+  const result = await openTextFileByPath(path);
+  return { result, stamp: stat.kind === "ok" ? stat.stamp : null };
+}
+
+/**
+ * Stamp a file without reading it, so an open document can be checked against
+ * disk cheaply. A path that no longer exists reports `missing` rather than an
+ * error — see lib/externalChange.ts for what the caller does with each outcome.
+ */
+export async function statTextFile(path: string): Promise<StatResult> {
+  try {
+    const stamp = await invoke<DiskStamp | null>("stat_text_file_by_path", {
+      path,
+    });
+    return stamp === null ? { kind: "missing" } : { kind: "ok", stamp };
+  } catch (err) {
+    console.warn("Failed to stat file:", err);
     return { kind: "error", message: friendlyMessage(err) };
   }
 }
@@ -191,6 +239,40 @@ export async function saveTextFileAs(
     console.warn("Failed to save file:", err);
     return { kind: "error", message: friendlyMessage(err) };
   }
+}
+
+/**
+ * Fire `handler` whenever the user comes back to markpad from somewhere else.
+ * This is the trigger for the external-change sweep (see lib/externalChange.ts):
+ * the window regaining focus is the moment the file they just edited elsewhere
+ * could have changed.
+ *
+ * Two sources, because neither alone is dependable across platforms: Tauri's own
+ * `tauri://focus`, which reports OS window focus, and the webview's DOM `focus`,
+ * which covers a webview that takes focus without the window event firing.
+ * Duplicate fires are expected and harmless — the sweep coalesces them.
+ */
+export async function subscribeToAppFocus(
+  handler: () => void,
+): Promise<() => void> {
+  const onDomFocus = () => handler();
+  window.addEventListener("focus", onDomFocus);
+
+  let unlistenTauri: (() => void) | null = null;
+  try {
+    unlistenTauri = await getCurrentWebviewWindow().onFocusChanged(
+      ({ payload: focused }) => {
+        if (focused) handler();
+      },
+    );
+  } catch (err) {
+    console.warn("Failed to subscribe to window focus:", err);
+  }
+
+  return () => {
+    window.removeEventListener("focus", onDomFocus);
+    unlistenTauri?.();
+  };
 }
 
 export async function setWindowTitle(fileName: string | null): Promise<void> {


### PR DESCRIPTION
Closes #108.

Edit a file MarkPad has open in another program, come back to the window, and
MarkPad now says so and offers to reload it.

## How it works

No filesystem watcher. That would mean a new dependency and a per-platform backend
for a workflow that is entirely "the user comes back to MarkPad", so the check is
driven by window focus (`tauri://focus` plus the webview's DOM `focus`, since
neither alone is dependable across platforms) and by activating a recents entry.

Each check is two steps, in `src/lib/externalChange.ts`:

1. stat the path — a new `stat_text_file_by_path` command returning mtime + length,
   or `null` for a path that no longer exists. Nothing else happens when the stamp
   still matches the revision already reconciled with, which is the common case and
   never reads.
2. only when the stamp moved, read the file and compare its bytes against what the
   buffer believes is on disk.

Step 2 is what keeps the notice honest: a `touch`, a save that wrote identical
bytes, and MarkPad's own writes all move the stamp without changing content, and
none of them should interrupt anyone. It also means a stamp that was never recorded
is safe to leave unknown — the first check reads once and settles — which is how a
file edited while MarkPad was closed still gets reported after a session restore,
and why saving simply clears the stamp instead of trying to predict its own write.

Both answers are recorded rather than just acted on. Reloading stamps the revision
it took; keeping your version stamps the revision you were shown. So the same
change never interrupts twice, while a later one still does.

## Behaviour worth calling out

- **Auto-save pauses while a notice is unanswered.** Auto-saving there would
  overwrite the outside edit before the user ever saw it. Answering either way
  releases the hold — saving over a reported change is a legitimate "my version
  wins".
- **A failed reload does not drop the item**, unlike a lazy activation load. Its
  buffer can hold the only copy of the user's work, so the error is reported and the
  notice stays up to retry.
- **Deletion is reported, not offered as a reload.** The buffer is the only copy
  left; saving writes the file again.
- **Clean inactive files get no marker, by design.** MarkPad already releases their
  buffers and re-reads them on activation, so there is no stale content to warn
  about and no decision to make. The recents marker is for files that kept a buffer
  — i.e. ones with unsaved edits, where a reload actually costs something.
- CRLF and BOM go through the same normalisation as the open path, so a Windows file
  is not reported as changed on every focus.

## Verification

- `npm test` — 22 new unit tests in `src/lib/externalChange.test.ts` cover the
  detection outcomes (stat-only fast path, touch, unknown baseline, deletion,
  re-nag suppression, transient stat/read failures) and the two sweep predicates.
- `npm run lint`, `npm run build`, `cargo fmt --check`, `cargo clippy --all-targets
  -- -D warnings` all clean.
- Driven end-to-end against the real frontend with Tauri's IPC replaced by an
  in-memory fake filesystem, in two scenarios — 29 checks, clean console:
  restore-and-read, touch stays quiet, outside edit reported, reload takes the disk
  version, dirty-buffer discard warning, dismissal sticks but a later edit still
  reports, deletion reported with no reload offered, save re-creates the file and
  raises no notice of its own; plus the inactive-modified-file path, where the
  recents marker appears, the banner holds off until the file is active, and the
  marker clears after the reload.
- Banner checked in light and dark.

  The harness drives the DOM `focus` half of the trigger; the `tauri://focus` half
  is a plain `onFocusChanged` subscription that needs the real shell, so it is worth
  a manual pass on a native build before merge.

## Not in scope

A live filesystem watcher, auto-reloading clean buffers without asking, and diffing
the disk version against the buffer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
